### PR TITLE
[MCC-177198] Added unit tests for extension methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 obj
 /Medidata.Cloud.Thermometer/New-NuGetPackages
 *.suo
+/TestResults/657eb892-25c1-4d9a-b6a1-644ecabad0be/*.coverage

--- a/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinRequestExtensionsTests.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinRequestExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Medidata.Cloud.Thermometer.Extensions;
+using Microsoft.Owin;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoRhinoMock;
+using Rhino.Mocks;
+
+namespace Medidata.Cloud.Thermometer.UnitTests.Extensions
+{
+    [TestClass]
+    public class OwinRequestExtensionsTests
+    {
+        private IFixture _fixture;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+        }
+
+        [TestMethod]
+        public void OwinRequest_ToThermometerQuestion_returns_Question()
+        {
+            // Arrange
+            var request = _fixture.Create<IOwinRequest>();
+            request.Stub(x => x.Path).Return(new PathString("/x/y/z"));
+            request.Stub(x => x.QueryString).Return(new QueryString("x=1&y=2"));
+
+            // Act
+            var result = request.ToThermometerQuestion();
+
+            // Assert
+            Assert.AreEqual("x.y.z", result.Name);
+            Assert.AreEqual("/x/y/z", result.Route);
+            CollectionAssert.AreEquivalent(new []{"x", "y"}, result.Keys.ToArray());
+            Assert.AreEqual("1", result["x"]);
+            Assert.AreEqual("2", result["y"]);
+        }
+    }
+}

--- a/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinResponseExtensionsTest.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinResponseExtensionsTest.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Web.Script.Serialization;
+using Medidata.Cloud.Thermometer.Extensions;
+using Microsoft.Owin;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoRhinoMock;
+using Rhino.Mocks;
+
+namespace Medidata.Cloud.Thermometer.UnitTests.Extensions
+{
+    [TestClass]
+    public class OwinResponseExtensionsTests
+    {
+        private IFixture _fixture;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+        }
+
+        [TestMethod]
+        public void OwinResponse_WriteAsJson_calls_OwinResponseWriteWithJson()
+        {
+            // Arrange
+            var response = _fixture.Create<IOwinResponse>();
+            var obj = new {x = 1, y = 2};
+            var json = new JavaScriptSerializer().Serialize(obj);
+
+            // Act
+            response.WriteAsJson(obj);
+
+            // Assert
+            response.AssertWasCalled(x => x.Write(json));
+        }
+    }
+}

--- a/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinResponseExtensionsTest.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/Extensions/OwinResponseExtensionsTest.cs
@@ -34,5 +34,20 @@ namespace Medidata.Cloud.Thermometer.UnitTests.Extensions
             // Assert
             response.AssertWasCalled(x => x.Write(json));
         }
+
+        [TestMethod]
+        public void OwinResponse_WriteAsJson_NullObject_returns_EmptyJson()
+        {
+            // Arrange
+            var response = _fixture.Create<IOwinResponse>();
+            var obj = new {};
+            var json = new JavaScriptSerializer().Serialize(obj);
+
+            // Act
+            response.WriteAsJson(null);
+
+            // Assert
+            response.AssertWasCalled(x => x.Write(json));
+        }
     }
 }

--- a/Medidata.Cloud.Thermometer.UnitTests/Medidata.Cloud.Thermometer.UnitTests.csproj
+++ b/Medidata.Cloud.Thermometer.UnitTests/Medidata.Cloud.Thermometer.UnitTests.csproj
@@ -66,6 +66,8 @@
   <ItemGroup>
     <Compile Include="Extensions\OwinResponseExtensionsTest.cs" />
     <Compile Include="Extensions\OwinRequestExtensionsTests.cs" />
+    <Compile Include="TestHelpers\FakeRootMiddelware.cs" />
+    <Compile Include="Middlewares\JsonResponseMiddlewareTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Medidata.Cloud.Thermometer.UnitTests/Medidata.Cloud.Thermometer.UnitTests.csproj
+++ b/Medidata.Cloud.Thermometer.UnitTests/Medidata.Cloud.Thermometer.UnitTests.csproj
@@ -35,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
     <Reference Include="Ploeh.AutoFixture">
       <HintPath>..\packages\AutoFixture.3.31.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
@@ -45,6 +49,7 @@
       <HintPath>..\packages\RhinoMocks.3.6\lib\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -59,6 +64,8 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Extensions\OwinResponseExtensionsTest.cs" />
+    <Compile Include="Extensions\OwinRequestExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Medidata.Cloud.Thermometer.UnitTests/Middlewares/JsonResponseMiddlewareTests.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/Middlewares/JsonResponseMiddlewareTests.cs
@@ -1,0 +1,50 @@
+﻿using Medidata.Cloud.Thermometer.Middlewares;
+using Medidata.Cloud.Thermometer.UnitTests.TestHelpers;
+using Microsoft.Owin;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoRhinoMock;
+using Rhino.Mocks;
+
+namespace Medidata.Cloud.Thermometer.UnitTests.Middlewares
+{
+    [TestClass]
+    public class JsonResponseMiddlewareTests
+    {
+        private IFixture _fixture;
+        private JsonResponseMiddleware _sut;
+        private OwinMiddleware _nextMiddleware;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+            _fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            _nextMiddleware = MockRepository.GenerateMock<OwinMiddleware>(new FakeRootMiddelware());
+
+            _sut = new JsonResponseMiddleware(_nextMiddleware);
+        }
+
+        [TestMethod]
+        public void Invoke_sets_ResponseHeaderAsNoCache()
+        {
+            // Arrange
+            var context = _fixture.Create<IOwinContext>();
+            context.Stub(x => x.Response).Return(_fixture.Create<IOwinResponse>());
+            context.Response.Stub(x => x.Headers).Return(_fixture.Create<IHeaderDictionary>());
+
+            // Act
+            var result = _sut.Invoke(context);
+            //result.Wait();
+
+            // Assert
+            context.AssertWasCalled(x => x.Response.Headers["Content-type"] = "application/json");
+            context.AssertWasCalled(x => x.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate");
+            context.AssertWasCalled(x => x.Response.Headers["Pragma"] = "no-cache");
+            context.AssertWasCalled(x => x.Response.Headers["Expires"] = "0");
+
+            _nextMiddleware.AssertWasCalled(x => x.Invoke(context));
+        }
+    }
+}

--- a/Medidata.Cloud.Thermometer.UnitTests/Middlewares/JsonResponseMiddlewareTests.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/Middlewares/JsonResponseMiddlewareTests.cs
@@ -19,10 +19,7 @@ namespace Medidata.Cloud.Thermometer.UnitTests.Middlewares
         public void Init()
         {
             _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
-            _fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
-            _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
             _nextMiddleware = MockRepository.GenerateMock<OwinMiddleware>(new FakeRootMiddelware());
-
             _sut = new JsonResponseMiddleware(_nextMiddleware);
         }
 

--- a/Medidata.Cloud.Thermometer.UnitTests/TestHelpers/FakeRootMiddelware.cs
+++ b/Medidata.Cloud.Thermometer.UnitTests/TestHelpers/FakeRootMiddelware.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Owin;
+
+namespace Medidata.Cloud.Thermometer.UnitTests.TestHelpers
+{
+    public class FakeRootMiddelware : OwinMiddleware
+    {
+        public FakeRootMiddelware() : base(null)
+        {
+        }
+
+        public override Task Invoke(IOwinContext context)
+        {
+            return Task.FromResult(context);
+        }
+    }
+}

--- a/Medidata.Cloud.Thermometer/Extensions/OwinResponseExtensions.cs
+++ b/Medidata.Cloud.Thermometer/Extensions/OwinResponseExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.Owin;
 
 namespace Medidata.Cloud.Thermometer.Extensions
 {
-    [ExcludeFromCodeCoverage]
     internal static class OwinResponseExtensions
     {
         internal static void WriteAsJson(this IOwinResponse owner, object target)


### PR DESCRIPTION
- Added unit tests for the extension methods of `IOwinRequest` and `IOwinResponse`.
- Added unit tests for JsonResponseMiddleware.

@art2003 @chenghuang-mdsol @vcapers-mdsol Please review and merge if OK.