### PR TITLE
[Housekeeping] Remove unused references from usage example project

### DIFF
--- a/Medidata.Cloud.Thermometer.Example/Medidata.Cloud.Thermometer.Example.csproj
+++ b/Medidata.Cloud.Thermometer.Example/Medidata.Cloud.Thermometer.Example.csproj
@@ -32,16 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Medidata.Cloud.Thermometer.Example/Program.cs
+++ b/Medidata.Cloud.Thermometer.Example/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 
 namespace Medidata.Cloud.Thermometer.Example


### PR DESCRIPTION
@art2003 @chenghuang-mdsol  Please review and merge. After this fix, the usage example project only references `System` and `Medidata.Cloud.Thermometer`.

![image](https://cloud.githubusercontent.com/assets/1455905/9315017/91ccc222-44fa-11e5-99cd-2f2371bad20a.png)
